### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ Briefly speaking, requests & aiohttp wrapper for asynchronous programming rookie
 **optional:**
 
     | psutil
-    | fuzzywuzzy
-    | python-Levenshtein
+    | rapidfuzz
     | pyperclip
 
 ## Features

--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,7 @@ To start:
     **optional:**
 
         | psutil
-        | fuzzywuzzy
-        | python-Levenshtein
+        | rapidfuzz
         | pyperclip
 
 Examples:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -32,8 +32,7 @@ To start:
     **optional:**
 
         | psutil
-        | fuzzywuzzy
-        | python-Levenshtein
+        | rapidfuzz
         | pyperclip
 
 Examples:

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         ],
         'all': [
             'pyOpenSSL >= 0.14', 'cryptography>=1.3.4', 'idna>=2.0.0',
-            'PySocks>=1.5.6, !=1.5.7', 'psutil', 'fuzzywuzzy', 'pyperclip'
+            'PySocks>=1.5.6, !=1.5.7', 'psutil', 'rapidfuzz', 'pyperclip'
         ],
     },
     python_requires=python_requires,

--- a/torequests/utils.py
+++ b/torequests/utils.py
@@ -665,7 +665,7 @@ class Regex(object):
         if not instances:
             return
         instances = sum(instances, [])
-        from fuzzywuzzy import process
+        from rapidfuzz import process
 
         maybe = process.extract(key, instances, limit=limit)
         return maybe


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.